### PR TITLE
Support old and new mqtt message format for gridPower

### DIFF
--- a/evcc-to-idm.rb
+++ b/evcc-to-idm.rb
@@ -37,6 +37,10 @@ client.get('evcc/site/#') do |topic, message|
     power = message.to_f
     puts "#{topic}: #{message}"
     send_modbus(74, power / 1000.0 * -1.0)
-  end
+  elsif topic == 'evcc/site/grid/power'
+    power = message.to_f
+    puts "#{topic}: #{message}"
+    send_modbus(74, power / 1000.0 * -1.0)
+  end    
 end
 


### PR DESCRIPTION
This PR https://github.com/evcc-io/evcc/pull/18063 changed the mqtt topic for the grid input/output from `evcc/site/gridPower` to `evcc/site/grid/power`

This adds support for both depending on when your evcc installation is updated.